### PR TITLE
Fix whisper num return sequences

### DIFF
--- a/scripts/validate_whisper_num_return_sequences.py
+++ b/scripts/validate_whisper_num_return_sequences.py
@@ -1,0 +1,63 @@
+import sys
+import datasets
+from datasets import Dataset
+from datasets import Audio
+from transformers import (
+        WhisperFeatureExtractor,
+        WhisperForConditionalGeneration,
+        WhisperTokenizer,
+        set_seed,
+    )
+
+
+def load_dataset():
+    return datasets.load_dataset(
+            "hf-internal-testing/librispeech_asr_dummy", "clean", split="validation"
+        )
+
+
+def load_datasamples(dataset, num_samples, seed=0):
+    speech_samples = dataset.sort("id").shuffle(seed).select(range(num_samples))[:num_samples]["audio"]
+    return [x["array"] for x in speech_samples]
+
+
+if __name__ == "__main__":
+    seed = int(sys.argv[1]) if len(sys.argv) > 1 else 123
+    audio_filename = sys.argv[2] if len(sys.argv) > 2 else None
+
+    model_id = "openai/whisper-tiny.en"
+
+    torch_device = "cpu"
+    set_seed(seed)
+    model = WhisperForConditionalGeneration.from_pretrained(model_id)
+    feature_extractor = WhisperFeatureExtractor.from_pretrained(model_id)
+    tokenizer = WhisperTokenizer.from_pretrained(model_id)
+    model.to(torch_device)
+
+    if audio_filename is None:
+        dataset = load_dataset()
+    else:
+        dataset = Dataset.from_dict(
+            {"audio": [audio_filename], "id": [audio_filename]}).cast_column("audio", Audio(sampling_rate=16000))
+
+    num_beams = 5
+    num_return_sequences = 5
+
+    input_speech = load_datasamples(dataset, 1, seed)
+    input_features = feature_extractor(input_speech, return_tensors="pt", sampling_rate=16_000).input_features
+
+    print("------------------------------------------------------------------")
+    print(f"Running {model_id} with {num_beams} beams and {num_return_sequences} return sequences...")
+
+    # Perform beam search
+    output = model.generate(
+        input_features,
+        num_beams=num_beams,
+        num_return_sequences=num_return_sequences,
+        return_dict_in_generate=True,
+        output_scores=True,
+    )
+
+    hypotheses = [tokenizer.decode(output_ids, skip_special_tokens=True) for output_ids in output.sequences]
+    for i, hypothesis in enumerate(hypotheses):
+        print(f"  Hypothesis {i + 1}: {hypothesis}")

--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -680,26 +680,10 @@ class WhisperGenerationMixin(GenerationMixin):
 
         # 5 Prepare running variables, list for generation
         num_return_sequences = generation_config.num_return_sequences
-        (
-            batch_idx_map,
-            cur_bsz,
-            input_features,
-            seek,
-            max_frames,
-            init_tokens,
-            do_condition_on_prev_tokens,
-        ) = self._expand_variables_for_generation(
-            input_features=input_features,
-            seek=seek,
-            max_frames=max_frames,
-            init_tokens=init_tokens,
-            batch_size=batch_size,
-            condition_on_prev_tokens=condition_on_prev_tokens,
-            generation_config=generation_config,
-        )
-        # cur_bsz = batch_size
-        # batch_idx_map = list(range(batch_size))
-        # do_condition_on_prev_tokens = [condition_on_prev_tokens for _ in range(cur_bsz)]
+        cur_bsz = batch_size
+        batch_idx_map = list(range(batch_size))
+        do_condition_on_prev_tokens = [condition_on_prev_tokens for _ in
+                                       range(cur_bsz * generation_config.num_return_sequences)]
 
         current_segments = self._prepare_segments(
             prompt_ids=prompt_ids,
@@ -1223,33 +1207,6 @@ class WhisperGenerationMixin(GenerationMixin):
                 should_skip = True
 
         return needs_fallback, should_skip
-
-    def _expand_variables_for_generation(
-        self, input_features, seek, max_frames, init_tokens, batch_size, condition_on_prev_tokens, generation_config
-    ):
-        # if generation_config.num_return_sequences is not None and generation_config.num_return_sequences > 1:
-        #     batch_idx_map = list(range(batch_size)) * generation_config.num_return_sequences
-        #     cur_bsz = len(batch_idx_map)
-        #     do_condition_on_prev_tokens = [condition_on_prev_tokens for _ in range(len(batch_idx_map))]
-        #     input_features = input_features.repeat_interleave(generation_config.num_return_sequences, dim=0)
-        #     seek = seek.repeat_interleave(generation_config.num_return_sequences, dim=0)
-        #     max_frames = max_frames.repeat_interleave(generation_config.num_return_sequences, dim=0)
-        #     init_tokens = init_tokens.repeat_interleave(generation_config.num_return_sequences, dim=0)
-        #     generation_config.num_return_sequences = 1
-        # else:
-        cur_bsz = batch_size
-        batch_idx_map = list(range(batch_size))
-        do_condition_on_prev_tokens = [condition_on_prev_tokens for _ in range(cur_bsz * generation_config.num_return_sequences)]
-
-        return (
-            batch_idx_map,
-            cur_bsz,
-            input_features,
-            seek,
-            max_frames,
-            init_tokens,
-            do_condition_on_prev_tokens,
-        )
 
     @staticmethod
     def _setup_no_speech_detection(logits_processor, segment_input, decoder_input_ids, kwargs):

--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -682,8 +682,9 @@ class WhisperGenerationMixin(GenerationMixin):
         num_return_sequences = generation_config.num_return_sequences
         cur_bsz = batch_size
         batch_idx_map = list(range(batch_size))
-        do_condition_on_prev_tokens = [condition_on_prev_tokens for _ in
-                                       range(cur_bsz * generation_config.num_return_sequences)]
+        do_condition_on_prev_tokens = [
+            condition_on_prev_tokens for _ in range(cur_bsz * generation_config.num_return_sequences)
+        ]
 
         current_segments = self._prepare_segments(
             prompt_ids=prompt_ids,
@@ -1077,7 +1078,7 @@ class WhisperGenerationMixin(GenerationMixin):
             if beam_indices is not None and key == "scores":
                 return [v[beam_idx].cpu() for (v, beam_idx) in zip(values, beam_indices[batch_idx][: len(values)])]
             if key in ["scores", "encoder_attentions", "encoder_hidden_states", "logits"]:
-                return [v[int(batch_idx/num_return_sequences)].cpu() for v in values]
+                return [v[int(batch_idx / num_return_sequences)].cpu() for v in values]
             if key in ["decoder_attentions", "decoder_hidden_states", "cross_attentions"]:
                 return tuple(tuple(w[batch_idx][None].cpu() for w in v) for v in values)
             elif key == "past_key_values":
@@ -1110,10 +1111,14 @@ class WhisperGenerationMixin(GenerationMixin):
         sequence_tokens = seek_outputs["sequences"][:, start_idx:]
         seek_outputs = [
             {
-                k: split_by_batch_index(v, k, i, is_shortform,
-                                        generation_config.num_return_sequences,
-                                        beam_indices=seek_outputs.get(
-                    "beam_indices"))
+                k: split_by_batch_index(
+                    v,
+                    k,
+                    i,
+                    is_shortform,
+                    generation_config.num_return_sequences,
+                    beam_indices=seek_outputs.get("beam_indices"),
+                )
                 for k, v in seek_outputs.items()
             }
             for i in range(sequence_tokens.shape[0])

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -526,7 +526,7 @@ class WhisperModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
         # Validate that beam search returns `num_return_sequences` distinct hypotheses
         for batch_idx in range(input_features.shape[0]):
             sequences = output.sequences[batch_idx * 3 : (batch_idx + 1) * 3]
-            unique_sequences = set(tuple(seq.tolist()) for seq in sequences)
+            unique_sequences = {tuple(seq.tolist()) for seq in sequences}
             self.assertEqual(len(unique_sequences), 3, "Beam search did not return distinct hypotheses.")
 
     # training is not supported yet
@@ -3217,7 +3217,7 @@ class WhisperModelIntegrationTests(unittest.TestCase):
         # assert re-ordered generations match those from eager
         self.assertTrue((eager_generated_ids[permutation_idx, :] == static_generated_ids).all())
 
-    # @slow
+    @slow
     def test_num_return_sequences(self):
         torch_device = "cpu"
         set_seed(0)

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -523,6 +523,12 @@ class WhisperModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
         self.assertEqual(output.beam_indices.shape[0], input_features.shape[0] * 3)
         self.assertEqual(output.sequences_scores.shape[0], input_features.shape[0] * 3)
 
+        # Validate that beam search returns `num_return_sequences` distinct hypotheses
+        for batch_idx in range(input_features.shape[0]):
+            sequences = output.sequences[batch_idx * 3 : (batch_idx + 1) * 3]
+            unique_sequences = set(tuple(seq.tolist()) for seq in sequences)
+            self.assertEqual(len(unique_sequences), 3, "Beam search did not return distinct hypotheses.")
+
     # training is not supported yet
     @unittest.skip(reason="Training is not supported yet")
     def test_training(self):

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -3217,19 +3217,30 @@ class WhisperModelIntegrationTests(unittest.TestCase):
         set_seed(0)
         model = WhisperForConditionalGeneration.from_pretrained("openai/whisper-tiny")
         model.to(torch_device)
-        input_speech = self._load_datasamples(1)
-        feature_extractor = WhisperFeatureExtractor.from_pretrained("openai/whisper-tiny")
-        tokenizer = WhisperTokenizer.from_pretrained("openai/whisper-tiny")
-        input_features = feature_extractor(input_speech, return_tensors="pt", sampling_rate=16_000).input_features
 
-        # Perform beam search
-        output = model.generate(
-            input_features, num_beams=3, num_return_sequences=3, return_dict_in_generate=True, output_scores=True
-        )
+        for batch_size, num_beams, num_return_sequences in [[1, 3, 3], [3, 3, 3], [3, 5, 3]]:
+            input_speech = self._load_datasamples(batch_size)
+            feature_extractor = WhisperFeatureExtractor.from_pretrained("openai/whisper-tiny")
+            tokenizer = WhisperTokenizer.from_pretrained("openai/whisper-tiny")
+            input_features = feature_extractor(input_speech, return_tensors="pt", sampling_rate=16_000).input_features
 
-        self.assertEqual(len(output.sequences), 3)
-        hypotheses = [tokenizer.decode(output_ids, skip_special_tokens=True) for output_ids in output.sequences]
-        self.assertEqual(len(set(hypotheses)), 3)  # All hypotheses should be different
+            # Perform beam search
+            output = model.generate(
+                input_features,
+                num_beams=num_beams,
+                num_return_sequences=num_return_sequences,
+                return_dict_in_generate=True,
+                output_scores=True,
+            )
+
+            self.assertEqual(len(output.sequences), num_return_sequences * batch_size)
+            hypotheses = [tokenizer.decode(output_ids, skip_special_tokens=True) for output_ids in output.sequences]
+            # Check that the hypotheses for each input are different
+            for i in range(batch_size):
+                self.assertEqual(
+                    len(set(hypotheses[i * num_return_sequences : (i + 1) * num_return_sequences])),
+                    num_return_sequences,
+                )
 
 
 @require_torch


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #33445

Added a new integration test `tests/models/whisper/test_modeling_whisper.py::test_num_return_sequences` and added a new check in `tests/models/whisper/test_modeling_whisper.py::test_beam_search_output` that asserts that beam search returns `num_return_sequences` distinct sequences.

In order to validate the change further, the script `scripts/validate_whisper_num_return_sequences.py` has been added.

On branch `main`, the current behaviour gives the same output repeated `num_return_sequences` times:

```
$ python validate_whisper_num_return_sequences.py                                      
------------------------------------------------------------------
Running openai/whisper-tiny.en with 5 beams and 5 return sequences...
  Hypothesis 1:  Nor is Mr. Quilter's manner less interesting than his matter.
  Hypothesis 2:  Nor is Mr. Quilter's manner less interesting than his matter.
  Hypothesis 3:  Nor is Mr. Quilter's manner less interesting than his matter.
  Hypothesis 4:  Nor is Mr. Quilter's manner less interesting than his matter.
  Hypothesis 5:  Nor is Mr. Quilter's manner less interesting than his matter.

```

whereas with the changes it results in distinct hypotheses as expected:

```
$ python validate_whisper_num_return_sequences.py         
------------------------------------------------------------------
Running openai/whisper-tiny.en with 5 beams and 5 return sequences...
  Hypothesis 1:  Nor is Mr. Quilter's manner less interesting than his matter.
  Hypothesis 2:  Nor is Mr. Colter's manner less interesting than his matter.
  Hypothesis 3:  Nor is Mr. Coulter's manner less interesting than his matter.
  Hypothesis 4:  Nor is Mr. Quilter's manner less interesting than his Matter.
  Hypothesis 5:  Nor is Mr. Colter's manner less interesting than his Matter.
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface, @SunMarc and @qgallouedec
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
